### PR TITLE
Switch from Firebase to SQLite database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+uploads/*
+!uploads/.gitkeep
+server/database.sqlite

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
@@ -21,7 +22,12 @@
     "react-dom": "^18.3.1",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.1.3",
-    "react-toastify": "^11.0.3"
+    "react-toastify": "^11.0.3",
+    "cors": "^2.8.5",
+    "express": "^4.21.1",
+    "multer": "^1.4.5-lts.1",
+    "sqlite": "^5.1.2",
+    "sqlite3": "^5.1.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,99 @@
+/* eslint-disable */
+import express from 'express';
+import cors from 'cors';
+import multer from 'multer';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { open } from 'sqlite';
+import sqlite3 from 'sqlite3';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+app.use('/uploads', express.static(path.join(__dirname, '../uploads')));
+
+const upload = multer({ dest: path.join(__dirname, '../uploads') });
+
+let db;
+(async () => {
+  db = await open({
+    filename: path.join(__dirname, 'database.sqlite'),
+    driver: sqlite3.Database
+  });
+  await db.exec(`CREATE TABLE IF NOT EXISTS voyages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    userId TEXT,
+    titre TEXT,
+    destination TEXT,
+    dateDepart TEXT,
+    dateRetour TEXT,
+    imageUrl TEXT
+  );`);
+  await db.exec(`CREATE TABLE IF NOT EXISTS items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    voyageId INTEGER,
+    type TEXT,
+    data TEXT,
+    FOREIGN KEY(voyageId) REFERENCES voyages(id) ON DELETE CASCADE
+  );`);
+})();
+
+// Récupérer les voyages d'un utilisateur
+app.get('/api/voyages', async (req, res) => {
+  const { userId } = req.query;
+  const voyages = await db.all('SELECT * FROM voyages WHERE userId = ?', userId);
+  const items = await db.all('SELECT * FROM items');
+  const formatted = voyages.map(v => ({
+    ...v,
+    items: items
+      .filter(i => i.voyageId === v.id)
+      .map(i => ({ type: i.type, data: JSON.parse(i.data) }))
+  }));
+  res.json(formatted);
+});
+
+// Récupérer le détail d'un voyage
+app.get('/api/voyages/:id', async (req, res) => {
+  const voyage = await db.get('SELECT * FROM voyages WHERE id = ?', req.params.id);
+  if (!voyage) return res.status(404).json({ error: 'Not found' });
+  const items = await db.all('SELECT * FROM items WHERE voyageId = ?', req.params.id);
+  voyage.items = items.map(i => ({ type: i.type, data: JSON.parse(i.data) }));
+  res.json(voyage);
+});
+
+// Création d'un voyage
+app.post('/api/voyages', upload.single('image'), async (req, res) => {
+  const { userId, titre, destination, dateDepart, dateRetour } = req.body;
+  const imageUrl = req.file ? `/uploads/${req.file.filename}` : null;
+  const result = await db.run(
+    'INSERT INTO voyages (userId, titre, destination, dateDepart, dateRetour, imageUrl) VALUES (?, ?, ?, ?, ?, ?)',
+    userId, titre, destination, dateDepart, dateRetour, imageUrl
+  );
+  const voyage = await db.get('SELECT * FROM voyages WHERE id = ?', result.lastID);
+  voyage.items = [];
+  res.json(voyage);
+});
+
+// Suppression d'un voyage
+app.delete('/api/voyages/:id', async (req, res) => {
+  await db.run('DELETE FROM voyages WHERE id = ?', req.params.id);
+  await db.run('DELETE FROM items WHERE voyageId = ?', req.params.id);
+  res.json({ success: true });
+});
+
+// Ajout d'un item à un voyage
+app.post('/api/voyages/:id/items', async (req, res) => {
+  const { type, data } = req.body;
+  await db.run('INSERT INTO items (voyageId, type, data) VALUES (?, ?, ?)', req.params.id, type, JSON.stringify(data));
+  const items = await db.all('SELECT * FROM items WHERE voyageId = ?', req.params.id);
+  const formatted = items.map(i => ({ type: i.type, data: JSON.parse(i.data) }));
+  res.json(formatted);
+});
+
+const PORT = process.env.PORT || 5000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/src/firebaseConfig.js
+++ b/src/firebaseConfig.js
@@ -1,7 +1,5 @@
 import { initializeApp } from "firebase/app";
 import { getAuth, GoogleAuthProvider, signInWithPopup, createUserWithEmailAndPassword, signInWithEmailAndPassword } from "firebase/auth";
-import { getFirestore } from "firebase/firestore";
-import { getStorage } from "firebase/storage";
 
 const firebaseConfig = {
   apiKey: "AIzaSyAk-WhXUmp4XtMnpXWPab1r-caJxIZ0CPg",
@@ -30,10 +28,6 @@ const signInWithGoogle = async () => {
   }
 };
 
-const db = getFirestore(app); // 🔥 Initialisation Firestore
-const storage = getStorage(app);
-
-export { db,storage };
 // Exporter l'auth et la fonction signInWithGoogle
 export { auth, signInWithGoogle, createUserWithEmailAndPassword, signInWithEmailAndPassword };
 export const googleProvider = new GoogleAuthProvider();

--- a/src/pages/HotelsPage.jsx
+++ b/src/pages/HotelsPage.jsx
@@ -77,7 +77,6 @@ function HotelsPage() {
   // Ajouter ces états au début du composant HotelsPage
   const [searchTerm, setSearchTerm] = useState('');
   const [airports, setAirports] = useState([]);
-  const [selectedAirport, setSelectedAirport] = useState(null);
   
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('');
 
@@ -135,7 +134,6 @@ const searchAirports = async (query) => {
 
 // Gérer la sélection d'un aéroport
 const handleAirportSelect = (airport) => {
-  setSelectedAirport(airport);
   setSearchTerm(airport.name);
   setCityCode(airport.iata_code);
   setAirports([]);

--- a/src/pages/VoyageDetail.jsx
+++ b/src/pages/VoyageDetail.jsx
@@ -1,7 +1,5 @@
 import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
-import { db } from "../firebaseConfig";
-import { doc, getDoc } from "firebase/firestore";
 import "./VoyageDetail.css";
 import { FaPlane, FaHotel, FaCar, FaArrowLeft, FaCalendar, FaMapMarkerAlt, FaClock, FaMoneyBillWave,FaUsers, FaRoad } from 'react-icons/fa';
 
@@ -14,10 +12,10 @@ function VoyageDetail() {
     const fetchVoyage = async () => {
       setLoading(true);
       try {
-        const docRef = doc(db, "voyages", id);
-        const docSnap = await getDoc(docRef);
-        if (docSnap.exists()) {
-          setVoyage({ id: docSnap.id, ...docSnap.data() });
+        const res = await fetch(`/api/voyages/${id}`);
+        if (res.ok) {
+          const data = await res.json();
+          setVoyage(data);
         } else {
           console.log("Voyage inexistant !");
         }

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:5000'
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- set up Express server with SQLite storage for voyages and items
- remove Firestore usage in travel pages and fetch data from new API
- add Vite proxy and NPM scripts to run the new backend

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689a1bbe69148327a5b79492df6ab0e3